### PR TITLE
add sample app key to .env.example. update Dockerfile with commands f…

### DIFF
--- a/laravel/.env.example
+++ b/laravel/.env.example
@@ -5,7 +5,7 @@
 # regardless of the contents of the .env file.
 APP_NAME=Laravel
 APP_ENV=local
-APP_KEY=
+APP_KEY=base64:i/FSGSqtDXCyel3SO4x+2MUXAohXEyQClsrc5Q9H2fY=
 APP_DEBUG=true
 APP_URL=http://localhost
 

--- a/laravel/Dockerfile
+++ b/laravel/Dockerfile
@@ -3,7 +3,19 @@ FROM php:8.1.0RC5-apache
 RUN docker-php-ext-install pdo pdo_mysql sockets
 RUN a2enmod rewrite
 
+# install programs/packages needed for composer updates/installs
+RUN apt-get -y update
+RUN apt-get -y install git zip unzip
+
+# install composer
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY . /var/www
+WORKDIR /var/www
+RUN composer update
+RUN composer install
+
+COPY ./.env.example /var/www/.env
 COPY ./public /var/www/html
+
 RUN chown -R www-data:www-data /var/www/


### PR DESCRIPTION
…or creating .env file and running composer update/install

Tidigare fanns ett problem när man försökte köra `docker compose up` där 'vendor'-mappen med composer-paket saknades, samt att det inte fanns någon .env-fil. Det här rättas till i och med den här PR:n genom att Dockerfilen för laravel-appen nu inkluderar kommandon för att installera composer och relaterade verktyg, köra composer update/install, och skapa en '.env'-fil genom att kopiera '.env.example'.