### PR TITLE
Edit/oauth

### DIFF
--- a/laravel/.env.circleci
+++ b/laravel/.env.circleci
@@ -64,3 +64,4 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # without any additional setup.
 GITHUB_CLIENT_ID=fc0584f4500c2f10422c
 GITHUB_CLIENT_SECRET=14911cbb50ca2adce7106d09a25e3edb28956076
+GITHUB_CALLBACK_URL=http://localhost:8000/api/auth/github/callback

--- a/laravel/.env.example
+++ b/laravel/.env.example
@@ -62,3 +62,4 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # without any additional setup.
 GITHUB_CLIENT_ID=fc0584f4500c2f10422c
 GITHUB_CLIENT_SECRET=14911cbb50ca2adce7106d09a25e3edb28956076
+GITHUB_CALLBACK_URL=http://localhost:8000/api/auth/github/callback

--- a/laravel/.env.testing
+++ b/laravel/.env.testing
@@ -62,3 +62,4 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # without any additional setup.
 GITHUB_CLIENT_ID=fc0584f4500c2f10422c
 GITHUB_CLIENT_SECRET=14911cbb50ca2adce7106d09a25e3edb28956076
+GITHUB_CALLBACK_URL=http://localhost:8000/api/auth/github/callback

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -35,6 +35,6 @@ return [
     'github' => [
         'client_id' => env('GITHUB_CLIENT_ID'),
         'client_secret' => env('GITHUB_CLIENT_SECRET'),
-        'redirect' => 'http://localhost:4200/api/auth/github/callback',
+        'redirect' => env('GITHUB_CALLBACK_URL'),
     ],
 ];


### PR DESCRIPTION
Uppdateringar för att möjliggöra nytt förslag på OAuth-flöde:
1. Frontend visar en 'logga in med GitHub'-knapp.

2. Användaren klickar på knappen.

3. Frontend gör en request till backend på http://localhost:8000/api/auth/github/redirect

4. Backend skickar tillbaka en JSON-respons som ser ut så här:
{"login_url":"https:\/\/github.com\/login\/oauth\/authorize?..."}

5. Länken (login_url) från steg 4 används av frontend för att skicka användaren till GitHub i en separat flik/tabb, där hen matar in användarnamn och lösenord. 'SCTR-fliken' ändras till att visa bara en knapp där det står 'Jag har loggat in', som användaren ska klicka på när hen är klar i den separata fliken.

6. Användare loggar in och GitHub skickar hen till backend på http://localhost:8000/api/auth/github/callback?code=....

7. Backend använder query-parametern code från GitHub och extraherar en token samt github username för användaren. Om  username:t inte finns i databas en ny 'user'-rad, och i vilket fall lagras token. En cookie 'oauth_token' sätts, som kommer att användas för att validera användaren vid kommande requests. Användaren ombeds stänga 'autentiseringsfliken'.

8. Användaren klickar i frontend på 'Jag har loggat in', och frontend gör en request till backend på http://localhost:8000/api/auth/github/check-usertype, får tillbaka en JSON-respons {"user_type": "user"|"admin"|"not_logged_in"}