### PR TITLE
Feature/auth improved

### DIFF
--- a/laravel/.env.circleci
+++ b/laravel/.env.circleci
@@ -64,4 +64,4 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # without any additional setup.
 GITHUB_CLIENT_ID=fc0584f4500c2f10422c
 GITHUB_CLIENT_SECRET=14911cbb50ca2adce7106d09a25e3edb28956076
-GITHUB_CALLBACK_URL=http://localhost:8000/api/auth/github/callback
+GITHUB_CALLBACK_URL=/api/auth/github/callback

--- a/laravel/.env.circleci
+++ b/laravel/.env.circleci
@@ -64,4 +64,5 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # without any additional setup.
 GITHUB_CLIENT_ID=fc0584f4500c2f10422c
 GITHUB_CLIENT_SECRET=14911cbb50ca2adce7106d09a25e3edb28956076
-GITHUB_CALLBACK_URL=/api/auth/github/callback
+GITHUB_CALLBACK_PATH_CUSTOMER=/api/auth/github/callback
+GITHUB_CALLBACK_PATH_ADMIN=/api/auth/github/callback/admin

--- a/laravel/.env.example
+++ b/laravel/.env.example
@@ -62,4 +62,4 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # without any additional setup.
 GITHUB_CLIENT_ID=fc0584f4500c2f10422c
 GITHUB_CLIENT_SECRET=14911cbb50ca2adce7106d09a25e3edb28956076
-GITHUB_CALLBACK_URL=http://localhost:8000/api/auth/github/callback
+GITHUB_CALLBACK_URL=/api/auth/github/callback

--- a/laravel/.env.example
+++ b/laravel/.env.example
@@ -62,4 +62,5 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # without any additional setup.
 GITHUB_CLIENT_ID=fc0584f4500c2f10422c
 GITHUB_CLIENT_SECRET=14911cbb50ca2adce7106d09a25e3edb28956076
-GITHUB_CALLBACK_URL=/api/auth/github/callback
+GITHUB_CALLBACK_PATH_CUSTOMER=/api/auth/github/callback
+GITHUB_CALLBACK_PATH_ADMIN=/api/auth/github/callback/admin

--- a/laravel/.env.testing
+++ b/laravel/.env.testing
@@ -62,4 +62,4 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # without any additional setup.
 GITHUB_CLIENT_ID=fc0584f4500c2f10422c
 GITHUB_CLIENT_SECRET=14911cbb50ca2adce7106d09a25e3edb28956076
-GITHUB_CALLBACK_URL=http://localhost:8000/api/auth/github/callback
+GITHUB_CALLBACK_URL=/api/auth/github/callback

--- a/laravel/.env.testing
+++ b/laravel/.env.testing
@@ -62,4 +62,5 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # without any additional setup.
 GITHUB_CLIENT_ID=fc0584f4500c2f10422c
 GITHUB_CLIENT_SECRET=14911cbb50ca2adce7106d09a25e3edb28956076
-GITHUB_CALLBACK_URL=/api/auth/github/callback
+GITHUB_CALLBACK_PATH_CUSTOMER=/api/auth/github/callback
+GITHUB_CALLBACK_PATH_ADMIN=/api/auth/github/callback/admin

--- a/laravel/app/Custom/Auth/Associate.php
+++ b/laravel/app/Custom/Auth/Associate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Custom\Auth\Associate;
+
+use Illuminate\Http\Request;
+
+class Associate {
+    public function isAssociateReq(Request $req) {
+        // TODO change way that token is extracted - it shouldn't be stored
+        // as a cookie, instead it should probably be plucked from a header
+        // or something.
+        $token = $req->cookie('associate_token');
+
+        // check if user actually has 'associate_token' cookie
+        if (! $token) {
+            return false;
+        }
+
+        // TODO add logic for checking user's token - what kind of token
+        // to generate, and how to store it (if at all) or at least check it
+        // is still to be determined.
+        return true;
+    }
+}

--- a/laravel/app/Http/Controllers/Sctr/OAuthController.php
+++ b/laravel/app/Http/Controllers/Sctr/OAuthController.php
@@ -84,11 +84,22 @@ class OAuthController extends Controller
 
     public function checkUserType(Request $req) {
         if (Customer::isCustomerReq($req)) {
-            return response()->json(['user_type' => 'customer']);
+            $customer = Customer::reqToCustomer($req);
+            return response()->json([
+                'user_type' => 'customer',
+                'id' => $customer->id
+            ]);
         }
         if (Adm::isAdmReq($req)) {
-            return response()->json(['user_type' => 'admin']);
+            $adm = Customer::reqToCustomer($req);
+            return response()->json([
+                'user_type' => 'admin',
+                'id' => $adm->id
+            ]);
         }
-        return response()->json(['user_type' => 'not_logged_in']);
+        return response()->json([
+            'user_type' => 'not_logged_in',
+            'id' => 'none'
+        ]);
     }
 }

--- a/laravel/app/Http/Controllers/Sctr/OAuthController.php
+++ b/laravel/app/Http/Controllers/Sctr/OAuthController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers\Sctr;
+
+use Illuminate\Support\Facades\URL;
+use Illuminate\Http\Request;
+
+use Laravel\Socialite\Facades\Socialite;
+
+use App\Http\Controllers\Controller;
+
+use App\Models\Adm; // Admin class
+use App\Models\Customer; // Customer class
+
+class OAuthController extends Controller
+{
+    private function githubRedirect(string $callbackPath) {
+        // overriding normal callback URL to ensure that user will be redirected
+        // back correctly by GitHub to continue customer login flow
+        $callbackUrl = URL::to($callbackPath);
+        // need to use 'stateless()' method here since API routes don't involve
+        // session middleware, and Socialite by default relies on Session. calling
+        // 'stateless()' disables this reliance.
+        $redirResp = Socialite::driver('github')
+            ->stateless()
+            ->with(['redirect_uri' => $callbackUrl])
+            ->redirect();
+
+        // return github login url, including 'redirect_uri' query parameter
+        return response()->json(
+            ['login_url' => $redirResp->getTargetUrl()]
+        );
+    }
+
+    public function githubRedirectCustomer() {
+        return self::githubRedirect(env('GITHUB_CALLBACK_PATH_CUSTOMER'));
+    }
+
+    public function githubRedirectAdmin() {
+        return self::githubRedirect(env('GITHUB_CALLBACK_PATH_ADMIN'));
+    }
+
+    public function githubCallbackCustomer() {
+        $user = Socialite::driver('github')->stateless()->user();
+
+        // if customer exists in database table, update its token. if the customer
+        // does _not_ exist, create it with the correct username and token
+        Customer::updateOrCreate(
+            ['username' => $user->getNickName()],
+            ['token' => $user->token ]
+        );
+
+        // the OAuth token is attached in a cookie, which should be sent with
+        // every following AJAX request from frontend. Note that the third
+        // argument of the cookie method says when the cookie is to expire
+        // in _minutes_ while the $user->expiresIn value is in _seconds_,
+        // hence we divide by 60.
+        return response(
+            'Hej ' . $user->getNickName() . '! Du är nu inloggad via GitHub.
+            Vänligen stäng den här fliken och återvänd till SCTR.'
+        )->cookie('oauth_token', $user->token, $user->expiresIn / 60);
+    }
+
+    public function githubCallbackAdmin() {
+        $user = Socialite::driver('github')->stateless()->user();
+
+        $adminRecord = Adm::firstWhere('username', $user->getNickName());
+
+        if (! $adminRecord) {
+            return response(
+                'Hej ' . $user->getNickName() . '! Du verkar inte vara en administratör.
+                Vänligen stäng webbgränssnittet för administratörer och gå in på en av
+                våra kundsidor istället.'
+            );
+        }
+
+        // TODO add saving to database once admin table also has a 'token' column.
+
+        return response(
+            'Hej ' . $user->getNickName() . '! Du är nu inloggad som admin via GitHub. 
+            Vänligen stäng den här fliken och återvänd till admingränssnittet.'
+        )->cookie('oauth_token', $user->token, $user->expiresIn / 60);
+    }
+
+    public function checkUserType(Request $req) {
+        if (Customer::isCustomerReq($req)) {
+            return response()->json(['user_type' => 'customer']);
+        }
+        if (Adm::isAdmReq($req)) {
+            return response()->json(['user_type' => 'admin']);
+        }
+        return response()->json(['user_type' => 'not_logged_in']);
+    }
+}

--- a/laravel/app/Models/Adm.php
+++ b/laravel/app/Models/Adm.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
 
 class Adm extends Model
 {
@@ -17,4 +18,17 @@ class Adm extends Model
         'username',
         'password'
     ];
+
+    public static function isAdmReq(Request $req) {
+        $token = $req->cookie('oauth_token');
+
+        // check if user actually has 'oauth_token' cookie
+        if (! $token) {
+            return false;
+        }
+        // TODO add logic for checking if user's token is in
+        // admin table 'token' column
+        return false;
+        return true;
+    }
 }

--- a/laravel/app/Models/Adm.php
+++ b/laravel/app/Models/Adm.php
@@ -31,4 +31,8 @@ class Adm extends Model
         return false;
         return true;
     }
+
+    public static function reqToAdm(Request $req) {
+        return self::firstWhere('token', $req->cookie('oauth_token'));
+    }
 }

--- a/laravel/app/Models/Customer.php
+++ b/laravel/app/Models/Customer.php
@@ -34,4 +34,8 @@ class Customer extends Model
         }
         return true;
     }
+
+    public static function reqToCustomer(Request $req) {
+        return self::firstWhere('token', $req->cookie('oauth_token'));
+    }
 }

--- a/laravel/app/Models/Customer.php
+++ b/laravel/app/Models/Customer.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
 
 class Customer extends Model
 {
@@ -14,9 +15,23 @@ class Customer extends Model
     // mass assignable properties - unsure what means
     // columns in table 'customer'
     protected $fillable = [
-        'username',
-        'password',
-        'funds',
-        'payment_terms'
+        // 'username',
+        'token'
+        // 'funds',
+        // 'payment_terms'
     ];
+
+    public static function isCustomerReq(Request $req) {
+        $token = $req->cookie('oauth_token');
+
+        // check if user actually has 'oauth_token' cookie
+        if (! $token) {
+            return false;
+        }
+        // check if user's token is in the database's customer table.
+        if (! self::firstWhere('token', $token)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -30,11 +30,9 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
-    // TODO change 'redirect' value to whatever frontend (full) URL
-    // is going to be used as callback once user has logged into GitHub.
     'github' => [
         'client_id' => env('GITHUB_CLIENT_ID'),
         'client_secret' => env('GITHUB_CLIENT_SECRET'),
-        'redirect' => env('GITHUB_CALLBACK_URL'),
+        'redirect' => env('GITHUB_CALLBACK_PATH_CUSTOMER'),
     ],
 ];

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -52,7 +52,14 @@ Route::put('/users/{id}',
 
 
 ////////// SCOOTERS //////////
-Route::get('/scooters', function () {
+Route::get('/scooters', function (Request $req) {
+    // NOTE NEW! Filtering based on who requested the data (customers
+    // only get active scooters) TODO ensure that correct filtering
+    // is applied for customers (more criteria needed? might be appropriate
+    // to create a custom method on Scooter class if filtering becomes complex)
+    if (Customer::isCustomerReq($req)) {
+        return Scooter::where('status', 'active')->get();
+    }
     return Scooter::all();
 });
 


### PR DESCRIPTION
Den här PR:en/grenen presenterar ett alternativt sätt att hantera admins/kunder/'samarbetspartners' (dvs de som ska använda auth separat från OAuth).

`App\Models\Customer` har nu en metod `isCustomerReq` som tar in en request och kontrollerar om den kommer från en kund. `App\Models\Adm` har en motsvarande metod `isAdmReq`.

För 'associates' så finns en särskild klass, som inte är en Laravel-modell (dvs inte kopplad till en databastabell), `App\Custom\Auth\Associate` med metod `isAssociateReq`.

Tanken är att vi kan använda de här funktionerna/metoderna för att kunna kontrollera vad för typ av användare som ställt en förfrågan och utifrån detta ändra på vad för data som returneras eller bedöma vad användaren har behörighet att göra.

Ett enkelt exempel finns för en av ändpunkterna:

```php
# routes/api.php
Route::get('/scooters', function (Request $req) {
    // Filtering based on who requested the data (customers
    // only get active scooters)
    if (Customer::isCustomerReq($req)) {
        return Scooter::where('status', 'active')->get();
    }
    return Scooter::all();
});
```

På det här sättet behöver vi inte skapa extra ändpunkter, vilket minskar hur mycket vi behöver hålla reda på, på både front- och backendsidan.

OAuth-login-relaterade ändpunkter har också uppdaterats, genom att lyfta ut logik till controllers och ordna så att OAuth-flöde nästan funkar för både kunder och admins. Jag säger 'nästan' då admintabellen först behöver få en 'token'-kolumn eller motsvarande. Se 'routes/api.php' samt OAuthController. 