### PR TITLE
Debug/oauth admin

### DIFF
--- a/laravel/app/Http/Controllers/Sctr/OAuthController.php
+++ b/laravel/app/Http/Controllers/Sctr/OAuthController.php
@@ -84,23 +84,23 @@ class OAuthController extends Controller
         return response(
             'Hej ' . $user->getNickName() . '! Du är nu inloggad som admin via GitHub. 
             Vänligen stäng den här fliken och återvänd till admingränssnittet.'
-        )->cookie('oauth_token', $user->token, $user->expiresIn / 60);
+        )->cookie('admin_oauth_token', $user->token, $user->expiresIn / 60);
     }
 
     public function checkUserType(Request $req)
     {
-        if (Customer::isCustomerReq($req)) {
-            $customer = Customer::reqToCustomer($req);
-            return response()->json([
-                'user_type' => 'customer',
-                'id' => $customer->id
-            ]);
-        }
         if (Adm::isAdmReq($req)) {
             $adm = Adm::reqToAdm($req);
             return response()->json([
                 'user_type' => 'admin',
                 'id' => $adm->id
+            ]);
+        }
+        if (Customer::isCustomerReq($req)) {
+            $customer = Customer::reqToCustomer($req);
+            return response()->json([
+                'user_type' => 'customer',
+                'id' => $customer->id
             ]);
         }
         return response()->json([

--- a/laravel/app/Http/Controllers/Sctr/ScooterController.php
+++ b/laravel/app/Http/Controllers/Sctr/ScooterController.php
@@ -18,6 +18,11 @@ class ScooterController extends Controller
     // between scooter update cache and database scooter table
     private static $cacheSendLatency = 5;
 
+    public function getSingleScooter($id)
+    {
+        return Scooter::where('id', $id)->get();
+    }
+
     public function getAllScooters(Request $req)
     {
         // NOTE NEW! Filtering based on who requested the data (customers

--- a/laravel/app/Models/Adm.php
+++ b/laravel/app/Models/Adm.php
@@ -22,9 +22,9 @@ class Adm extends Model
 
     public static function isAdmReq(Request $req)
     {
-        $token = $req->cookie('oauth_token');
+        $token = $req->cookie('admin_oauth_token');
 
-        // check if user actually has 'oauth_token' cookie
+        // check if user actually has 'admin_oauth_token' cookie
         if (! $token) {
             return false;
         }
@@ -37,6 +37,6 @@ class Adm extends Model
 
     public static function reqToAdm(Request $req)
     {
-        return self::firstWhere('token', $req->cookie('oauth_token'));
+        return self::firstWhere('token', $req->cookie('admin_oauth_token'));
     }
 }

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -73,16 +73,17 @@ Route::put(
 ////////// SCOOTERS //////////
 Route::get('/scooters', [ScooterController::class, 'getAllScooters']);
 
-Route::get('/scooters/{id}', function ($id) {
-    return Scooter::where('id', $id)->get();
-});
+Route::get('/scooters/{id}', [ScooterController::class, 'getSingleScooter']);
 
 Route::put(
     '/scooters/{id}',
     'App\Http\Controllers\Sctr\ScooterController@updateScooter'
 );
 
+// routes specifically for use by scooter client/simulator //
 Route::get('/scooter-client/scooters/', [ScooterController::class, 'getAllScooters']);
+Route::get('/scooter-client/scooters/{id}', [ScooterController::class, 'getSingleScooter']);
+
 Route::put('/scooter-client/scooters/{id}', [ScooterController::class, 'updateScooterCache']);
 
 Route::post('/scooter-client/scooters/flush-cache', [ScooterController::class, 'syncCacheWithDatabase']);

--- a/laravel/tests/Feature/ScooterTest.php
+++ b/laravel/tests/Feature/ScooterTest.php
@@ -69,6 +69,90 @@ class ScooterTest extends TestCase
     }
 
     /**
+     * GET /api/scooters/{id} as customer returns single scooter.
+     */
+    public function testSingleScooterCustomer()
+    {
+        $response = $this->call(
+            'GET',
+            '/api/scooters/1',
+            [],
+            ['oauth_token' => $this->validCustomerToken]
+        );
+
+        $response
+            ->assertStatus(200);
+
+        $response
+            ->assertJson(fn (AssertableJson $json) => 
+                $json
+                ->has(1)
+                ->first(fn ($json) =>
+                    $json
+                        ->where('id', 1)
+                        ->etc()
+                )
+        );
+    }
+
+    /**
+    * GET /api/scooter-client/scooters as scooter simulator returns all scooters.
+    */
+    public function testScootersSimulator()
+    {
+        $response = $this->call(
+            'GET',
+            '/api/scooter-client/scooters',
+            [],
+            []
+        );
+
+        $response
+            ->assertStatus(200);
+        
+        // there should 4 scooters, since the scooter seeder
+        // creates 4, and simulator should get access to all of them.
+        $response
+            ->assertJson(fn (AssertableJson $json) => 
+                $json
+                    ->has(4)
+                    ->first(fn ($json) =>
+                        $json
+                            ->where('id', 1)
+                            ->where('city_id', 1)
+                            ->etc()
+                    )
+        );
+    }
+
+    /**
+     * GET /api/scooter-client/scooters/{id} as scooter simulator returns single scooter.
+     */
+    public function testSingleScooterSimulator()
+    {
+        $response = $this->call(
+            'GET',
+            '/api/scooter-client/scooters/1',
+            [],
+            []
+        );
+
+        $response
+            ->assertStatus(200);
+
+        $response
+            ->assertJson(fn (AssertableJson $json) => 
+                $json
+                ->has(1)
+                ->first(fn ($json) =>
+                    $json
+                        ->where('id', 1)
+                        ->etc()
+                )
+        );
+    }
+
+    /**
      * POST /api/scooter-client/scooters/flush-cache flushes cache to database 
      */
     public function testSyncCacheWithDatabase()


### PR DESCRIPTION
Fixat så att oauth för admins använder en separat cookie-nyckel från den som används för kunder/'vanliga användare', så att man ska kunna vara inloggad som admin och kund samtidigt. Även ordnat en del saker med scooter-client-ändpunkter och caching lock, se commits.